### PR TITLE
Added checkerframework-local profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,41 @@
   </dependencies>
 
   <profiles>
+    <!-- Profile to use the version of Checker Framework installed locally-->
+    <profile>
+      <id>checkerframework-local</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
+          <version>0.0.0</version>
+          <scope>system</scope>
+          <systemPath>${CHECKERFRAMEWORK}/checker/dist/checker-qual.jar</systemPath>
+        </dependency>
+        <dependency>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker</artifactId>
+          <version>0.0.0</version>
+          <scope>system</scope>
+          <systemPath>${CHECKERFRAMEWORK}/checker/dist/checker.jar</systemPath>
+        </dependency>
+        <dependency>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>compiler</artifactId>
+          <version>0.0.0</version>
+          <scope>system</scope>
+          <systemPath>${CHECKERFRAMEWORK}/checker/dist/javac.jar</systemPath>
+        </dependency>
+        <dependency>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>jdk7</artifactId>
+          <version>0.0.0</version>
+          <scope>system</scope>
+          <systemPath>${CHECKERFRAMEWORK}/checker/dist/jdk7.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+
     <profile>
       <id>jdk7</id>
       <activation>


### PR DESCRIPTION
This profile uses the version of the Checker Framework installed locally
as specified by CHECKERFRAMEWORK environment variable. 
Activate the profile like so:

```
mvn compile -P checkeframework-local 
```
